### PR TITLE
Gdpr mam remove

### DIFF
--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -325,12 +325,14 @@ mam_required_modules(retrieve_mam_pm, Backend) ->
 mam_required_modules(CN, Backend) when CN =:= retrieve_mam_pm_and_muc_light_dont_interfere;
                                        CN =:= retrieve_mam_muc_light ->
     [{mod_mam_meta, [{backend, Backend},
+                     {db_message_format, mam_message_eterm}, %% used only by riak & cassandra backends
                      {pm, [{archive_groupchats, false}]},
                      {muc, [{host, "muclight.@HOST@"}]}]},
      {mod_muc_light, [{host, "muclight.@HOST@"}]}];
 mam_required_modules(retrieve_mam_pm_and_muc_light_interfere, Backend) ->
     [{mod_mam_meta, [{backend, Backend},
                      {rdbms_message_format, simple}, %% ignored for any other than rdbms backend
+                     {db_message_format, mam_message_xml}, %% used only by riak & cassandra backends
                      {pm, [{archive_groupchats, true}]},
                      {muc, [{host, "muclight.@HOST@"}]}]},
      {mod_muc_light, [{host, "muclight.@HOST@"}]}].

--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -137,9 +137,13 @@ groups() ->
      {remove_personal_data_with_mods_disabled, [], removal_testcases()},
      {remove_personal_data_inbox, [], [remove_inbox, remove_inbox_muclight, remove_inbox_muc]},
      {remove_personal_data_mam, [], [
-                                     {group, remove_personal_data_mam_rdbms}
+                                     {group, remove_personal_data_mam_rdbms},
+                                     {group, remove_personal_data_mam_riak},
+                                     {group, remove_personal_data_mam_cassandra}
                                     ]},
-     {remove_personal_data_mam_rdbms, [], mam_removal_testcases()}].
+     {remove_personal_data_mam_rdbms, [], mam_removal_testcases()},
+     {remove_personal_data_mam_riak, [], mam_removal_testcases()},
+     {remove_personal_data_mam_cassandra, [], mam_removal_testcases()}].
 
 
 removal_testcases() ->
@@ -194,9 +198,11 @@ init_per_group(retrieve_personal_data_pubsub, Config) ->
 init_per_group(GN, Config) when GN =:= remove_personal_data_mam_rdbms;
                                 GN =:= retrieve_personal_data_mam_rdbms ->
     try_backend_for_mam(Config, rdbms);
-init_per_group(retrieve_personal_data_mam_riak, Config) ->
+init_per_group(GN, Config) when GN =:= retrieve_personal_data_mam_riak;
+                                GN =:= remove_personal_data_mam_riak ->
     try_backend_for_mam(Config, riak);
-init_per_group(retrieve_personal_data_mam_cassandra, Config) ->
+init_per_group(GN, Config) when GN =:= retrieve_personal_data_mam_cassandra;
+                                GN =:= remove_personal_data_mam_cassandra->
     try_backend_for_mam(Config, cassandra);
 init_per_group(retrieve_personal_data_mam_elasticsearch, Config) ->
     try_backend_for_mam(Config, elasticsearch);

--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -131,7 +131,7 @@ groups() ->
      {retrieve_personal_data_mam_rdbms, [], mam_testcases()},
      {retrieve_personal_data_mam_riak, [], mam_testcases()},
      {retrieve_personal_data_mam_cassandra, [], mam_testcases()},
-     {retrieve_personal_data_mam_elasticsearch, [], [retrieve_mam_pm]},
+     {retrieve_personal_data_mam_elasticsearch, [], mam_testcases()},
      {remove_personal_data, [], removal_testcases()},
      {remove_personal_data_with_mods_disabled, [], removal_testcases()},
      {remove_personal_data_inbox, [], [remove_inbox, remove_inbox_muclight, remove_inbox_muc]}].

--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -21,6 +21,7 @@
          dont_remove_other_user_private_xml/1,
          retrieve_roster/1,
          retrieve_mam_pm/1,
+         remove_mam_pm/1,
          retrieve_mam_muc_light/1,
          retrieve_mam_pm_and_muc_light_interfere/1,
          retrieve_mam_pm_and_muc_light_dont_interfere/1,
@@ -134,7 +135,12 @@ groups() ->
      {retrieve_personal_data_mam_elasticsearch, [], mam_testcases()},
      {remove_personal_data, [], removal_testcases()},
      {remove_personal_data_with_mods_disabled, [], removal_testcases()},
-     {remove_personal_data_inbox, [], [remove_inbox, remove_inbox_muclight, remove_inbox_muc]}].
+     {remove_personal_data_inbox, [], [remove_inbox, remove_inbox_muclight, remove_inbox_muc]},
+     {remove_personal_data_mam, [], [
+                                     {group, remove_personal_data_mam_rdbms}
+                                    ]},
+     {remove_personal_data_mam_rdbms, [], mam_removal_testcases()}].
+
 
 removal_testcases() ->
     [
@@ -144,7 +150,13 @@ removal_testcases() ->
         remove_private,
         remove_multiple_private_xmls,
         dont_remove_other_user_private_xml,
-        {group, remove_personal_data_inbox}
+        {group, remove_personal_data_inbox},
+        {group, remove_personal_data_mam}
+    ].
+
+mam_removal_testcases() ->
+    [
+     remove_mam_pm
     ].
 
 
@@ -179,7 +191,8 @@ init_per_group(GN, Config) when GN =:= retrieve_personal_data_with_mods_disabled
 init_per_group(retrieve_personal_data_pubsub, Config) ->
     dynamic_modules:ensure_modules(domain(), pubsub_required_modules()),
     Config;
-init_per_group(retrieve_personal_data_mam_rdbms, Config) ->
+init_per_group(GN, Config) when GN =:= remove_personal_data_mam_rdbms;
+                                GN =:= retrieve_personal_data_mam_rdbms ->
     try_backend_for_mam(Config, rdbms);
 init_per_group(retrieve_personal_data_mam_riak, Config) ->
     try_backend_for_mam(Config, riak);
@@ -250,7 +263,8 @@ init_per_testcase(CN, Config) when CN =:= remove_private;
 init_per_testcase(CN, Config) when CN =:= retrieve_mam_muc_light;
                                    CN =:= retrieve_mam_pm_and_muc_light_interfere;
                                    CN =:= retrieve_mam_pm_and_muc_light_dont_interfere;
-                                   CN =:= retrieve_mam_pm ->
+                                   CN =:= retrieve_mam_pm;
+                                   CN =:= remove_mam_pm ->
     case proplists:get_value(mam_backend, Config, skip) of
         skip ->
             {skip, no_mam_backend_configured};
@@ -319,7 +333,8 @@ muclight_domain() ->
     Domain = inbox_helper:domain(),
     <<"muclight.", Domain/binary>>.
 
-mam_required_modules(retrieve_mam_pm, Backend) ->
+mam_required_modules(CN, Backend) when CN =:= remove_mam_pm;
+                                       CN =:= retrieve_mam_pm->
     [{mod_mam_meta, [{backend, Backend},
                      {pm, [{archive_groupchats, false}]}]}];
 mam_required_modules(CN, Backend) when CN =:= retrieve_mam_pm_and_muc_light_dont_interfere;
@@ -591,6 +606,42 @@ retrieve_mam_pm(Config) ->
 
             retrieve_and_validate_personal_data(
                 Alice, Config, "mam_pm", ExpectedHeader, ExpectedItems, ["from", "message"]),
+            retrieve_and_validate_personal_data(
+                Bob, Config, "mam_pm", ExpectedHeader, ExpectedItems, ["from", "message"])
+        end,
+    escalus_fresh:story(Config, [{alice, 1}, {bob, 1}], F).
+
+remove_mam_pm(Config) ->
+    F = fun(Alice, Bob) ->
+            Msg1 = <<"1remove_mam_pm message">>,
+            Msg2 = <<"2remove_mam_pm message message">>,
+            Msg3 = <<"3remove_mam_pm message message">>,
+            escalus:send(Alice, escalus_stanza:chat_to(Bob, Msg1)),
+            escalus:send(Bob, escalus_stanza:chat_to(Alice, Msg2)),
+            escalus:send(Alice, escalus_stanza:chat_to(Bob, Msg3)),
+            [mam_helper:wait_for_archive_size(User, 3) || User <- [Alice, Bob]],
+            AliceJID = escalus_client:full_jid(Alice),
+            BobJID = escalus_client:full_jid(Bob),
+
+            ExpectedHeader = ["id", "from", "message"],
+            ExpectedItems = [
+                                #{"message" => [{contains, Msg1}], "from" => [{jid, AliceJID}]},
+                                #{"message" => [{contains, Msg3}], "from" => [{jid, AliceJID}]},
+                                #{"message" => [{contains, Msg2}], "from" => [{jid, BobJID}]}
+                            ],
+
+            BackendModule = choose_mam_backend(Config, mam),
+            maybe_stop_and_unload_module(mod_mam, BackendModule, Config),
+            {0, _} = unregister(Alice, Config),
+
+            AliceU = escalus_utils:jid_to_lower(escalus_client:username(Alice)),
+            AliceS = escalus_utils:jid_to_lower(escalus_client:server(Alice)),
+            mongoose_helper:wait_until(
+              fun() ->
+                      mongoose_helper:successful_rpc(mod_mam, get_personal_data,
+                                                     [AliceU, AliceS])
+              end, [{mam_pm, ExpectedHeader, []}]),
+
             retrieve_and_validate_personal_data(
                 Bob, Config, "mam_pm", ExpectedHeader, ExpectedItems, ["from", "message"])
         end,

--- a/big_tests/tests/gdpr_SUITE.erl
+++ b/big_tests/tests/gdpr_SUITE.erl
@@ -139,11 +139,13 @@ groups() ->
      {remove_personal_data_mam, [], [
                                      {group, remove_personal_data_mam_rdbms},
                                      {group, remove_personal_data_mam_riak},
-                                     {group, remove_personal_data_mam_cassandra}
+                                     {group, remove_personal_data_mam_cassandra},
+                                     {group, remove_personal_data_mam_elasticsearch}
                                     ]},
      {remove_personal_data_mam_rdbms, [], mam_removal_testcases()},
      {remove_personal_data_mam_riak, [], mam_removal_testcases()},
-     {remove_personal_data_mam_cassandra, [], mam_removal_testcases()}].
+     {remove_personal_data_mam_cassandra, [], mam_removal_testcases()},
+     {remove_personal_data_mam_elasticsearch, [], mam_removal_testcases()}].
 
 
 removal_testcases() ->
@@ -204,7 +206,8 @@ init_per_group(GN, Config) when GN =:= retrieve_personal_data_mam_riak;
 init_per_group(GN, Config) when GN =:= retrieve_personal_data_mam_cassandra;
                                 GN =:= remove_personal_data_mam_cassandra->
     try_backend_for_mam(Config, cassandra);
-init_per_group(retrieve_personal_data_mam_elasticsearch, Config) ->
+init_per_group(GN, Config) when GN =:= retrieve_personal_data_mam_elasticsearch;
+                                GN =:= remove_personal_data_mam_elasticsearch ->
     try_backend_for_mam(Config, elasticsearch);
 init_per_group(retrieve_personal_data_inbox = GN, Config) ->
     init_inbox(GN, Config, muclight);

--- a/big_tests/tests/mam_SUITE.erl
+++ b/big_tests/tests/mam_SUITE.erl
@@ -689,7 +689,7 @@ init_modules(rdbms, muc_all, Config) ->
     init_module(host(), mod_mam_muc, [{host, muc_domain(Config)}]),
     Config;
 init_modules(rdbms_simple, muc_all, Config) ->
-    init_module(host(), mod_mam_muc_rdbms_arch, [muc, simple]),
+    init_module(host(), mod_mam_muc_rdbms_arch, [muc, rdbms_simple_opts()]),
     init_module(host(), mod_mam_rdbms_prefs, [muc]),
     init_module(host(), mod_mam_rdbms_user, [muc]),
     init_module(host(), mod_mam_muc, [{host, muc_domain(Config)}]),
@@ -750,7 +750,7 @@ init_modules(rdbms, C, Config) ->
     Config;
 init_modules(rdbms_simple, C, Config) ->
     init_module(host(), mod_mam, addin_mam_options(C, Config)),
-    init_module(host(), mod_mam_rdbms_arch, [pm, simple]),
+    init_module(host(), mod_mam_rdbms_arch, [pm, rdbms_simple_opts()]),
     init_module(host(), mod_mam_rdbms_prefs, [pm]),
     init_module(host(), mod_mam_rdbms_user, [pm]),
     Config;
@@ -814,6 +814,9 @@ init_modules(rdbms_mnesia_cache, C, Config) ->
     init_module(host(), mod_mam_rdbms_user, [pm]),
     init_module(host(), mod_mam_cache_user, [pm]),
     Config.
+
+rdbms_simple_opts() ->
+    [{db_jid_format, mam_jid_rfc}, {db_message_format, mam_message_xml}].
 
 init_modules_for_muc_light(BackendType, Config) ->
     dynamic_modules:start(host(), mod_muc_light, [{host, binary_to_list(muc_light_host())}]),

--- a/big_tests/tests/muc_SUITE.erl
+++ b/big_tests/tests/muc_SUITE.erl
@@ -379,7 +379,7 @@ init_per_group(G, Config) when G =:= http_auth_no_server;
 init_per_group(hibernation, Config) ->
     case mam_helper:backend() of
         rdbms ->
-    dynamic_modules:start(domain(), mod_mam_muc_rdbms_arch, [muc, simple]),
+    dynamic_modules:start(domain(), mod_mam_muc_rdbms_arch, [muc]),
     dynamic_modules:start(domain(), mod_mam_rdbms_prefs, [muc]),
     dynamic_modules:start(domain(), mod_mam_rdbms_user, [muc]),
             dynamic_modules:start(domain(), mod_mam_muc, [{host, "muc.@HOST@"}]);

--- a/big_tests/tests/rest_helper.erl
+++ b/big_tests/tests/rest_helper.erl
@@ -274,7 +274,7 @@ to_list(V) when is_list(V) ->
     V.
 
 maybe_enable_mam(rdbms, Host, Config) ->
-    init_module(Host, mod_mam_rdbms_arch, [muc, pm, simple]),
+    init_module(Host, mod_mam_rdbms_arch, [muc, pm]),
     init_module(Host, mod_mam_rdbms_prefs, [muc, pm]),
     init_module(Host, mod_mam_rdbms_user, [muc, pm]),
     init_module(Host, mod_mam, []),

--- a/priv/elasticsearch/muc.json
+++ b/priv/elasticsearch/muc.json
@@ -8,6 +8,9 @@
 				"room": {
 					"type": "keyword"
 				},
+				"from_jid" : {
+					"type": "keyword"
+				},
 				"source_jid": {
 					"type": "keyword"
 				},

--- a/src/mam/mod_mam.erl
+++ b/src/mam/mod_mam.erl
@@ -347,6 +347,8 @@ remove_user(User, Server) ->
     ArcJID = jid:make(User, Server, <<>>),
     Host = server_host(ArcJID),
     ArcID = archive_id_int(Host, ArcJID),
+    Backends = mongoose_lib:find_behaviour_implementations(ejabberd_gen_mam_archive)
+    ++ mongoose_lib:find_behaviour_implementations(ejabberd_gen_mam_prefs),
     lists:foreach(fun(B) ->
         try
             B:remove_archive(Host, ArcID, ArcJID)
@@ -357,7 +359,7 @@ remove_user(User, Server) ->
                 "reason=~p:~p "
                 "stacktrace=~1000p ", [E, R, Stack]),
                 ok
-        end end, mongoose_lib:find_behaviour_implementations(ejabberd_gen_mam_archive)).
+        end end, Backends).
 
 sm_filter_offline_message(_Drop=false, _From, _To, Packet) ->
     %% If ...

--- a/src/mam/mod_mam_cassandra_arch.erl
+++ b/src/mam/mod_mam_cassandra_arch.erl
@@ -772,18 +772,9 @@ stored_binary_to_packet(Bin) ->
 %%      {db_message_format, module()}
 %%      ])
 compile_params_module(Params) ->
-    CodeStr = params_helper(expand_simple_param(Params)),
+    CodeStr = params_helper(Params),
     {Mod, Code} = dynamic_compile:from_string(CodeStr),
     code:load_binary(Mod, "mod_mam_cassandra_arch_params.erl", Code).
-
-expand_simple_param(Params) ->
-    lists:flatmap(fun(simple) -> simple_params();
-                     ({simple, true}) -> simple_params();
-                     (Param) -> [Param]
-                  end, Params).
-
-simple_params() ->
-    [{db_message_format, mam_message_xml}].
 
 params_helper(Params) ->
     binary_to_list(iolist_to_binary(io_lib:format(

--- a/src/mam/mod_mam_cassandra_arch.erl
+++ b/src/mam/mod_mam_cassandra_arch.erl
@@ -206,12 +206,12 @@ remove_archive(Acc, Host, UserID, UserJID) ->
     remove_archive(Host, UserID, UserJID),
     Acc.
 
-remove_archive(_Host, _UserID, UserJID) ->
+remove_archive(Host, _UserID, UserJID) ->
+    ensure_params_loaded(Host),
+    PoolName = mod_mam_cassandra_arch_params:pool_name(),
     BUserJID = bare_jid(UserJID),
-    PoolName = pool_name(UserJID),
     Params = #{user_jid => BUserJID},
     %% Wait until deleted
-
     DeleteFun =
         fun(Rows, _AccIn) ->
                 mongoose_cassandra:cql_write(PoolName, UserJID, ?MODULE,

--- a/src/mam/mod_mam_cassandra_arch.erl
+++ b/src/mam/mod_mam_cassandra_arch.erl
@@ -18,6 +18,7 @@
 -export([archive_size/4,
          archive_message/9,
          lookup_messages/3,
+         remove_archive/3,
          remove_archive/4]).
 
 %% mongoose_cassandra callbacks
@@ -201,7 +202,11 @@ remove_archive_offsets_query_cql() ->
 select_for_removal_query_cql() ->
     "SELECT DISTINCT user_jid, with_jid FROM mam_message WHERE user_jid = ?".
 
-remove_archive(Acc, _Host, _UserID, UserJID) ->
+remove_archive(Acc, Host, UserID, UserJID) ->
+    remove_archive(Host, UserID, UserJID),
+    Acc.
+
+remove_archive(_Host, _UserID, UserJID) ->
     BUserJID = bare_jid(UserJID),
     PoolName = pool_name(UserJID),
     Params = #{user_jid => BUserJID},
@@ -216,9 +221,7 @@ remove_archive(Acc, _Host, _UserID, UserJID) ->
         end,
 
     mongoose_cassandra:cql_foldl(PoolName, UserJID, ?MODULE,
-                                 select_for_removal_query, Params, DeleteFun, []),
-    Acc.
-
+                                 select_for_removal_query, Params, DeleteFun, []).
 %% ----------------------------------------------------------------------
 %% SELECT MESSAGES
 

--- a/src/mam/mod_mam_cassandra_prefs.erl
+++ b/src/mam/mod_mam_cassandra_prefs.erl
@@ -18,6 +18,7 @@
 -export([get_behaviour/5,
          get_prefs/4,
          set_prefs/7,
+         remove_archive/3,
          remove_archive/4]).
 
 -export([prepared_queries/0]).
@@ -200,13 +201,16 @@ get_prefs({GlobalDefaultMode, _, _}, _Host, _UserID, UserJID) ->
 
 -spec remove_archive(any(), jid:server(), mod_mam:archive_id(),
                      jid:jid()) -> any().
-remove_archive(Acc, _Host, _UserID, UserJID) ->
+remove_archive(Acc, Host, UserID, UserJID) ->
+    remove_archive(Host, UserID, UserJID),
+    Acc.
+
+remove_archive(_Host, _UserID, UserJID) ->
     PoolName = pool_name(UserJID),
     BUserJID = mod_mam_utils:bare_jid(UserJID),
     Now = mongoose_cassandra:now_timestamp(),
     Params = #{'[timestamp]' => Now, user_jid => BUserJID},
-    mongoose_cassandra:cql_write(PoolName, UserJID, ?MODULE, del_prefs_ts_query, [Params]),
-    Acc.
+    mongoose_cassandra:cql_write(PoolName, UserJID, ?MODULE, del_prefs_ts_query, [Params]).
 
 
 -spec query_behaviour(jid:server(), UserJID :: jid:jid(), BUserJID :: binary() | string(),

--- a/src/mam/mod_mam_elasticsearch_arch.erl
+++ b/src/mam/mod_mam_elasticsearch_arch.erl
@@ -28,7 +28,8 @@
 %% ejabberd_gen_mam_archive callbacks
 -export([archive_message/9]).
 -export([lookup_messages/3]).
--export([remove_archive/4]).
+-export([remove_archive/3,
+         remove_archive/4]).
 -export([archive_size/4]).
 
 -export([get_mam_pm_gdpr_data/2]).
@@ -137,7 +138,11 @@ archive_size(_Size, _Host, _ArchiveId, OwnerJid) ->
                      Host :: jid:server(),
                      ArchiveId :: mod_mam:archive_id(),
                      OwnerJid :: jid:jid()) -> Acc when Acc :: map().
-remove_archive(Acc, Host, _ArchiveId, OwnerJid) ->
+remove_archive(Acc, Host, ArchiveId, OwnerJid) ->
+    remove_archive(Host, ArchiveId, OwnerJid),
+    Acc.
+
+remove_archive(Host, _ArchiveId, OwnerJid) ->
     SearchQuery = build_search_query(#{owner_jid => OwnerJid}),
     case mongoose_elasticsearch:delete_by_query(?INDEX_NAME, ?TYPE_NAME, SearchQuery) of
         ok ->
@@ -146,8 +151,7 @@ remove_archive(Acc, Host, _ArchiveId, OwnerJid) ->
             ?ERROR_MSG("event=remove_archive_failed server=~s user=~s reason=~1000p",
                        [Host, jid:to_binary(OwnerJid), Err]),
             ok
-    end,
-    Acc.
+    end.
 
 %%-------------------------------------------------------------------
 %% Helpers

--- a/src/mam/mod_mam_meta.erl
+++ b/src/mam/mod_mam_meta.erl
@@ -102,24 +102,23 @@ handle_nested_opts(Key, RootOpts, Default, Deps) ->
 -spec parse_opts(Type :: pm | muc, Opts :: proplists:proplist(), deps()) -> deps().
 parse_opts(Type, Opts, Deps) ->
     CoreMod = mam_type_to_core_mod(Type),
-
-    CoreModOpts =
-        lists:filtermap(
-          fun(Key) ->
-                  case proplists:lookup(Key, Opts) of
-                      none -> false;
-                      Opt -> {true, Opt}
-                  end
-          end, valid_core_mod_opts(CoreMod)),
-
+    CoreModOpts = filter_opts(Opts, valid_core_mod_opts(CoreMod)),
     WithCoreDeps = add_dep(CoreMod, CoreModOpts, Deps),
     Backend = proplists:get_value(backend, Opts, rdbms),
-
     parse_backend_opts(Backend, Type, Opts, WithCoreDeps).
 
 -spec mam_type_to_core_mod(atom()) -> module().
 mam_type_to_core_mod(pm) -> mod_mam;
 mam_type_to_core_mod(muc) -> mod_mam_muc.
+
+filter_opts(Opts, ValidOpts) ->
+    lists:filtermap(
+        fun(Key) ->
+            case proplists:lookup(Key, Opts) of
+                none -> false;
+                Opt -> {true, Opt}
+            end
+        end, ValidOpts).
 
 -spec valid_core_mod_opts(module()) -> [atom()].
 valid_core_mod_opts(mod_mam) ->
@@ -152,7 +151,8 @@ parse_backend_opts(cassandra, Type, Opts, Deps0) ->
             muc -> mod_mam_muc_cassandra_arch
         end,
 
-    Deps = add_dep(ModArch, Deps0),
+    Opts1 = filter_opts(Opts, [db_message_format, pool_name]),
+    Deps = add_dep(ModArch, Opts1, Deps0),
 
     case proplists:get_value(user_prefs_store, Opts, false) of
         cassandra -> add_dep(mod_mam_cassandra_prefs, [Type], Deps);
@@ -161,7 +161,8 @@ parse_backend_opts(cassandra, Type, Opts, Deps0) ->
     end;
 
 parse_backend_opts(riak, Type, Opts, Deps0) ->
-    Deps = add_dep(mod_mam_riak_timed_arch_yz, [Type], Deps0),
+    Opts1 = filter_opts(Opts, [db_message_format]),
+    Deps = add_dep(mod_mam_riak_timed_arch_yz, [Type | Opts1], Deps0),
 
     case proplists:get_value(user_prefs_store, Opts, false) of
         mnesia -> add_dep(mod_mam_mnesia_prefs, [Type], Deps);
@@ -181,25 +182,17 @@ parse_backend_opts(rdbms, Type, Opts0, Deps0) ->
     Deps = add_dep(mod_mam_rdbms_user, [Type], Deps1),
 
     lists:foldl(
-      pa:bind(fun parse_backend_opt/5, Type, ModRDBMSArch, ModAsyncWriter),
+      pa:bind(fun parse_rdbms_opt/5, Type, ModRDBMSArch, ModAsyncWriter),
       Deps, Opts);
 
 parse_backend_opts(elasticsearch, Type, Opts, Deps0) ->
-    ExtraOpts =
-        case proplists:get_value(elasticsearch_index_name, Opts) of
-            IndexName when is_binary(IndexName) ->
-                [{index_name, IndexName}];
-            _ ->
-                []
-        end,
-
     ModArch =
         case Type of
             pm -> mod_mam_elasticsearch_arch;
             muc -> mod_mam_muc_elasticsearch_arch
         end,
 
-    Deps = add_dep(ModArch, ExtraOpts, Deps0),
+    Deps = add_dep(ModArch, Deps0),
 
     case proplists:get_value(user_prefs_store, Opts, false) of
         mnesia -> add_dep(mod_mam_mnesia_prefs, [Type], Deps);
@@ -219,7 +212,7 @@ add_dep(Dep, Deps) ->
 -spec add_dep(Dep :: module(), Args :: proplists:proplist(), deps()) -> deps().
 add_dep(Dep, Args, Deps) ->
     PrevArgs = maps:get(Dep, Deps, []),
-    NewArgs = Args ++ PrevArgs,
+    NewArgs = lists:usort(Args ++ PrevArgs),
     maps:put(Dep, NewArgs, Deps).
 
 
@@ -236,9 +229,9 @@ add_default_rdbms_opts(Opts) ->
       [{cache_users, true}, {async_writer, true}]).
 
 
--spec parse_backend_opt(Type :: pm | muc, module(), module(),
+-spec parse_rdbms_opt(Type :: pm | muc, module(), module(),
                         Option :: {module(), term()}, deps()) -> deps().
-parse_backend_opt(Type, ModRDBMSArch, ModAsyncWriter, Option, Deps) ->
+parse_rdbms_opt(Type, ModRDBMSArch, ModAsyncWriter, Option, Deps) ->
     case Option of
         {cache_users, true} ->
             add_dep(mod_mam_cache_user, [Type], Deps);

--- a/src/mam/mod_mam_muc.erl
+++ b/src/mam/mod_mam_muc.erl
@@ -242,7 +242,7 @@ archive_room_packet(Packet, FromNick, FromJID=#jid{}, RoomJID=#jid{}, Role, Affi
             MessID = generate_message_id(),
             Packet1 = replace_x_user_element(FromJID, Role, Affiliation, Packet),
             Result = archive_message(Host, MessID, ArcID,
-                                     RoomJID, SrcJID, SrcJID, incoming, Packet1),
+                                     RoomJID, mod_mam_utils:bare_jid(FromJID), SrcJID, incoming, Packet1),
             %% Packet2 goes to archive, Packet to other users
             case Result of
                 ok ->

--- a/src/mam/mod_mam_muc_cassandra_arch.erl
+++ b/src/mam/mod_mam_muc_cassandra_arch.erl
@@ -887,18 +887,9 @@ stored_binary_to_packet(Bin) ->
 %%      {db_message_format, module()}
 %%      ])
 compile_params_module(Params) ->
-    CodeStr = params_helper(expand_simple_param(Params)),
+    CodeStr = params_helper(Params),
     {Mod, Code} = dynamic_compile:from_string(CodeStr),
     code:load_binary(Mod, "mod_mam_muc_cassandra_arch_params.erl", Code).
-
-expand_simple_param(Params) ->
-    lists:flatmap(fun(simple) -> simple_params();
-                     ({simple, true}) -> simple_params();
-                     (Param) -> [Param]
-                  end, Params).
-
-simple_params() ->
-    [{db_message_format, mam_muc_message_xml}].
 
 params_helper(Params) ->
     binary_to_list(iolist_to_binary(io_lib:format(

--- a/src/mam/mod_mam_muc_elasticsearch_arch.erl
+++ b/src/mam/mod_mam_muc_elasticsearch_arch.erl
@@ -31,6 +31,9 @@
 -export([remove_archive/4]).
 -export([archive_size/4]).
 
+%gdpr
+-export([get_mam_muc_gdpr_data/2]).
+
 -include("mongoose.hrl").
 -include("mongoose_rsm.hrl").
 -include("mod_mam.hrl").
@@ -56,12 +59,28 @@ stop(Host) ->
 %%-------------------------------------------------------------------
 %% ejabberd_gen_mam_archive callbacks
 %%-------------------------------------------------------------------
+-spec get_mam_muc_gdpr_data(jid:username(), jid:server()) ->
+    {ok, ejabberd_gen_mam_archive:mam_muc_gdpr_data()}.
+get_mam_muc_gdpr_data(User, Host) ->
+    Source = jid:make(User, Host, <<"">>),
+    BinSource = mod_mam_utils:bare_jid(Source),
+    Filter = #{term => #{from_jid => BinSource}},
+    Sorting = #{mam_id => #{order => asc}},
+    SearchQuery = #{query => #{bool => #{filter => Filter}},
+                    sort => Sorting},
+    case mongoose_elasticsearch:search(?INDEX_NAME, ?TYPE_NAME, SearchQuery) of
+        {ok, #{<<"hits">> := #{<<"hits">> := Hits}}} ->
+            Messages = lists:map(fun hit_to_gdpr_mam_message/1, Hits),
+            {ok, Messages};
+        {error, _} ->
+            {ok, []}
+    end.
 
-archive_message(_Result, Host, MessageId, _UserId, RoomJid, _SourceJid, SourceJid, _Dir, Packet) ->
+archive_message(_Result, Host, MessageId, _UserId, RoomJid, FromJID, SourceJid, _Dir, Packet) ->
     Room = mod_mam_utils:bare_jid(RoomJid),
     SourceBinJid = mod_mam_utils:full_jid(SourceJid),
     DocId = make_document_id(Room, MessageId),
-    Doc = make_document(MessageId, Room, SourceBinJid, Packet),
+    Doc = make_document(MessageId, Room, SourceBinJid, Packet, FromJID),
     case mongoose_elasticsearch:insert_document(?INDEX_NAME, ?TYPE_NAME, DocId, Doc) of
         {ok, _} ->
             ok;
@@ -144,10 +163,11 @@ hooks(Host) ->
 make_document_id(Room, MessageId) ->
     <<Room/binary, $$, (integer_to_binary(MessageId))/binary>>.
 
--spec make_document(mod_mam:message_id(), binary(), binary(), exml:element()) ->
-    map().
-make_document(MessageId, Room, SourceBinJid, Packet) ->
+-spec make_document(mod_mam:message_id(), binary(), binary(), exml:element(),
+                    binary()) -> map().
+make_document(MessageId, Room, SourceBinJid, Packet, FromJID) ->
     #{mam_id     => MessageId,
+      from_jid   => FromJID,
       room       => Room,
       source_jid => SourceBinJid,
       message    => exml:to_binary(Packet),
@@ -256,6 +276,11 @@ hit_to_mam_message(#{<<"_source">> := JSON}) ->
 
     {ok, Stanza} = exml:parse(Packet),
     {MessageId, jid:from_binary(SourceJid), Stanza}.
+
+hit_to_gdpr_mam_message(#{<<"_source">> := JSON}) ->
+    MessageId = maps:get(<<"mam_id">>, JSON),
+    Packet = maps:get(<<"message">>, JSON),
+    {integer_to_binary(MessageId), Packet}.
 
 %% Usage of RSM affects the `"total"' value returned by ElasticSearch. Per RSM spec, the count
 %% returned by the query should represent the size of the whole result set, which in case of MAM

--- a/src/mam/mod_mam_rdbms_arch.erl
+++ b/src/mam/mod_mam_rdbms_arch.erl
@@ -21,6 +21,7 @@
 -export([archive_size/4,
          archive_message/9,
          lookup_messages/3,
+         remove_archive/3,
          remove_archive/4]).
 
 -export([get_mam_pm_gdpr_data/2]).
@@ -461,13 +462,16 @@ row_to_message_id({BMessID, _, _}) ->
 -spec remove_archive(Acc :: map(), Host :: jid:server(),
                      ArchiveID :: mod_mam:archive_id(),
                      RoomJID :: jid:jid()) -> map().
-remove_archive(Acc, Host, UserID, _UserJID) ->
+remove_archive(Acc, Host, UserID, UserJID) ->
+    remove_archive(Host, UserID, UserJID),
+    Acc.
+
+remove_archive(Host, UserID, _UserJID) ->
     {updated, _} =
     mod_mam_utils:success_sql_query(
       Host,
       ["DELETE FROM mam_message "
-       "WHERE user_id = ", use_escaped_integer(escape_user_id(UserID))]),
-    Acc.
+       "WHERE user_id = ", use_escaped_integer(escape_user_id(UserID))]).
 
 %% @doc Each record is a tuple of form
 %% `{<<"13663125233">>, <<"bob@localhost">>, <<binary>>}'.

--- a/src/mam/mod_mam_rdbms_async_pool_writer.erl
+++ b/src/mam/mod_mam_rdbms_async_pool_writer.erl
@@ -28,6 +28,7 @@
 -export([archive_size/4,
          archive_message/9,
          lookup_messages/3,
+         remove_archive/3,
          remove_archive/4]).
 
 %% Helpers for debugging
@@ -237,6 +238,9 @@ lookup_messages(Result, Host, #{archive_id := ArcID, end_ts := End, now := Now})
 remove_archive(Acc, Host, ArcID, _ArcJID)
     when is_integer(ArcID) ->
     Acc.
+
+remove_archive(_Host, _ArcID, _ArcJID) ->
+    ok.
 
 %%====================================================================
 %% Internal functions

--- a/src/mam/mod_mam_rdbms_user.erl
+++ b/src/mam/mod_mam_rdbms_user.erl
@@ -15,6 +15,7 @@
 
 %% ejabberd handlers
 -export([archive_id/3,
+         remove_archive/3,
          remove_archive/4]).
 
 %% gdpr functions
@@ -146,7 +147,11 @@ get_archive_id(Host, User) ->
 -spec remove_archive(Acc :: map(), Host :: jid:server(),
                      ArchiveID :: mod_mam:archive_id(),
                      ArchiveJID :: jid:jid()) -> map().
-remove_archive(Acc, Host, _ArcID, _ArcJID=#jid{lserver = Server, luser = UserName}) ->
+remove_archive(Acc, Host, ArcID, ArcJID) ->
+    remove_archive(Host, ArcID, ArcJID),
+    Acc.
+
+remove_archive(Host, _ArcID, _ArcJID=#jid{lserver = Server, luser = UserName}) ->
     SUserName = mongoose_rdbms:escape_string(UserName),
     SServer   = mongoose_rdbms:escape_string(Server),
     {updated, _} =
@@ -154,8 +159,7 @@ remove_archive(Acc, Host, _ArcID, _ArcJID=#jid{lserver = Server, luser = UserNam
       Host,
       ["DELETE FROM mam_server_user "
        "WHERE server = ", mongoose_rdbms:use_escaped_string(SServer),
-            " AND user_name = ", mongoose_rdbms:use_escaped_string(SUserName)]),
-    Acc.
+            " AND user_name = ", mongoose_rdbms:use_escaped_string(SUserName)]).
 
 %%====================================================================
 %% Internal functions

--- a/src/mam/mod_mam_riak_timed_arch_yz.erl
+++ b/src/mam/mod_mam_riak_timed_arch_yz.erl
@@ -31,6 +31,7 @@
          stop/1,
          archive_size/4,
          lookup_messages/2,
+         remove_archive/3,
          remove_archive/4]).
 
 -export([archive_message/9,

--- a/test/mod_mam_meta_SUITE.erl
+++ b/test/mod_mam_meta_SUITE.erl
@@ -98,11 +98,17 @@ produces_valid_configurations(_Config) ->
 
 
 handles_riak_config(_Config) ->
-    Deps = deps([{backend, riak}, {pm, [{user_prefs_store, mnesia}]}, {muc, []}]),
+    Deps = deps([
+                 {backend, riak},
+                 {db_message_format, some_format},
+                 {pm, [{user_prefs_store, mnesia}]},
+                 {muc, []}
+                ]),
 
     ?assert(lists:keymember(mod_mam, 1, Deps)),
     ?assert(lists:keymember(mod_mam_muc, 1, Deps)),
     check_has_args(mod_mam_riak_timed_arch_yz, [pm, muc], Deps),
+    check_has_args(mod_mam_riak_timed_arch_yz, [{db_message_format, some_format}], Deps),
     check_has_args(mod_mam_mnesia_prefs, [pm], Deps),
     check_has_no_args(mod_mam_mnesia_prefs, [muc], Deps).
 
@@ -110,14 +116,16 @@ handles_riak_config(_Config) ->
 handles_cassandra_config(_Config) ->
     Deps = deps([
                  {backend, cassandra},
-                 {pm, [{user_prefs_store, cassandra}]},
-                 {muc, [{user_prefs_store, mnesia}]}
+                 {pm, [{user_prefs_store, cassandra}, {db_message_format, some_format}]},
+                 {muc, [{user_prefs_store, mnesia}, {pool_name, some_poolname}]}
                 ]),
 
-    ?assert(lists:keymember(mod_mam_cassandra_arch, 1, Deps)),
-    ?assert(lists:keymember(mod_mam_muc_cassandra_arch, 1, Deps)),
     check_has_args(mod_mam_mnesia_prefs, [muc], Deps),
-    check_has_args(mod_mam_cassandra_prefs, [pm], Deps).
+    check_has_args(mod_mam_cassandra_prefs, [pm], Deps),
+    check_has_args(mod_mam_cassandra_arch, [{db_message_format, some_format}], Deps),
+    check_has_args(mod_mam_muc_cassandra_arch, [{pool_name, some_poolname}], Deps),
+    check_has_no_args(mod_mam_cassandra_arch, [{pool_name, some_poolname}], Deps),
+    check_has_no_args(mod_mam_muc_cassandra_arch, [{db_message_format, some_format}], Deps).
 
 
 example_muc_only_no_pref_good_performance(_Config) ->


### PR DESCRIPTION
This PR tests & implements personal user data removal from `mod_mam`.

**DONE**:
- Remove personal data from mod_mam with enabled backend modules.
- Remove personal data from disabled backend modules: RDBMS, riak, cassandra

**TODO**
- Remove personal data from disabled backend modules: elasticsearch.

